### PR TITLE
[review] ref/queryがクリアされた際にステートが正しく初期化されるように

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sonicgarden/react-fire-hooks",
   "type": "module",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "React hooks for Firebase",
   "main": "dist/cjs/index.js",
   "module": "dist/index.js",

--- a/src/firestore/_tests/useCollectionData.test.ts
+++ b/src/firestore/_tests/useCollectionData.test.ts
@@ -84,6 +84,7 @@ describe('useCollectionData', async () => {
 
     rerender({ ref: null });
     await waitFor(() => {
+      expect(result.current.loading).toBe(undefined);
       expect(result.current.data.length).toBe(0);
     });
   });

--- a/src/firestore/_tests/useCollectionDataOnce.test.ts
+++ b/src/firestore/_tests/useCollectionDataOnce.test.ts
@@ -68,6 +68,27 @@ describe('useCollectionDataOnce', async () => {
     });
   });
 
+  it('clear data when the query changes to null', async () => {
+    const { result, waitFor, rerender } = renderHook<
+      { ref: Parameters<typeof useCollectionDataOnce>[0] },
+      ReturnType<typeof useCollectionDataOnce>
+    >(({ ref }) => useCollectionDataOnce(ref), {
+      initialProps: { ref: fruitsRef() },
+    });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    await waitFor(() => {
+      expect(result.current.data.length).toBe(2);
+      expect(result.current.data).toContainEqual(expect.objectContaining({ name: 'apple' }));
+      expect(result.current.data).toContainEqual(expect.objectContaining({ name: 'banana' }));
+    });
+
+    rerender({ ref: null });
+    await waitFor(() => {
+      expect(result.current.loading).toBe(undefined);
+      expect(result.current.data.length).toBe(0);
+    });
+  });
+
   it('does not refetch data when the data is updated', async () => {
     const { result, waitFor } = renderHook(() => useCollectionDataOnce(fruitsRef()));
     await waitFor(() => expect(result.current.loading).toBe(false));

--- a/src/firestore/_tests/useDocumentData.test.ts
+++ b/src/firestore/_tests/useDocumentData.test.ts
@@ -68,6 +68,7 @@ describe('useDocumentData', async () => {
     expect(result.current.data).toEqual({ name: 'apple' });
     rerender({ ref: null });
     await waitFor(() => {
+      expect(result.current.loading).toBe(undefined);
       expect(result.current.data).toBe(undefined);
     });
   });

--- a/src/firestore/_tests/useDocumentDataOnce.test.ts
+++ b/src/firestore/_tests/useDocumentDataOnce.test.ts
@@ -57,6 +57,22 @@ describe('useDocumentDataOnce', async () => {
     });
   });
 
+  it('clears data when the document reference changes to null', async () => {
+    const { result, waitFor, rerender } = renderHook<
+      { ref: Parameters<typeof useDocumentDataOnce>[0] | null },
+      ReturnType<typeof useDocumentDataOnce>
+    >(({ ref }) => useDocumentDataOnce(ref), { initialProps: { ref: fruitRef('apple') } });
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.data).toEqual({ name: 'apple' });
+    rerender({ ref: null });
+    await waitFor(() => {
+      expect(result.current.loading).toBe(undefined);
+      expect(result.current.data).toBe(undefined);
+    });
+  });
+
   it('does not refetch data when the data is updated', async () => {
     const { result, waitFor } = renderHook(() => useDocumentDataOnce(fruitRef('apple')));
     await waitFor(() => expect(result.current.loading).toBe(false));

--- a/src/firestore/_tests/useDocumentsData.test.ts
+++ b/src/firestore/_tests/useDocumentsData.test.ts
@@ -71,6 +71,7 @@ describe('useDocumentsData', async () => {
     expect(result.current.data).toEqual([{ name: 'apple' }, { name: 'banana' }]);
     rerender({ refs: [] });
     await waitFor(() => {
+      expect(result.current.loading).toBe(undefined);
       expect(result.current.data).toEqual([]);
     });
   });

--- a/src/firestore/_tests/useDocumentsDataOnce.test.ts
+++ b/src/firestore/_tests/useDocumentsDataOnce.test.ts
@@ -61,6 +61,21 @@ describe('useDocumentsDataOnce', async () => {
     });
   });
 
+  it('clears data when the references change to empty array', async () => {
+    const { result, waitFor, rerender } = renderHook(({ refs }) => useDocumentsDataOnce(refs), {
+      initialProps: { refs: [fruitRef('apple'), fruitRef('banana')] },
+    });
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.data).toEqual([{ name: 'apple' }, { name: 'banana' }]);
+    rerender({ refs: [] });
+    await waitFor(() => {
+      expect(result.current.loading).toBe(undefined);
+      expect(result.current.data).toEqual([]);
+    });
+  });
+
   it('does not refetch data when the data is updated', async () => {
     const { result, waitFor } = renderHook(() => useDocumentsDataOnce([fruitRef('apple'), fruitRef('banana')]));
     await waitFor(() => expect(result.current.loading).toBe(false));

--- a/src/firestore/_tests/usePaginatedCollectionData.test.ts
+++ b/src/firestore/_tests/usePaginatedCollectionData.test.ts
@@ -19,7 +19,9 @@ describe('usePaginatedCollectionData', async () => {
       addDoc(fruitsRef(), { name: 'cherry' }),
       addDoc(fruitsRef(), { name: 'date' }),
       addDoc(vegetablesRef(), { name: 'carrot' }),
+      addDoc(vegetablesRef(), { name: 'onion' }),
       addDoc(vegetablesRef(), { name: 'potato' }),
+      addDoc(vegetablesRef(), { name: 'tomato' }),
     ]);
   });
 
@@ -67,7 +69,53 @@ describe('usePaginatedCollectionData', async () => {
     await waitFor(() => {
       expect(result.current.data.length).toBe(2);
       expect(result.current.data).toContainEqual(expect.objectContaining({ name: 'carrot' }));
-      expect(result.current.data).toContainEqual(expect.objectContaining({ name: 'potato' }));
+      expect(result.current.data).toContainEqual(expect.objectContaining({ name: 'onion' }));
+    });
+  });
+
+  it('clears data when the query changes to null', async () => {
+    const { result, waitFor, rerender } = renderHook<
+      { ref: Parameters<typeof usePaginatedCollectionData>[0] },
+      ReturnType<typeof usePaginatedCollectionData>
+    >(({ ref }) => usePaginatedCollectionData(ref, { limit: 2 }), {
+      initialProps: { ref: query(fruitsRef(), orderBy('name')) },
+    });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    await waitFor(() => {
+      expect(result.current.data.length).toBe(2);
+      expect(result.current.data).toContainEqual(expect.objectContaining({ name: 'apple' }));
+      expect(result.current.data).toContainEqual(expect.objectContaining({ name: 'banana' }));
+    });
+
+    rerender({ ref: null });
+    await waitFor(() => {
+      expect(result.current.loading).toBe(undefined);
+      expect(result.current.data.length).toBe(0);
+    });
+  });
+
+  it('resets pagination when the query changes', async () => {
+    const { result, waitFor, rerender } = renderHook(({ ref }) => usePaginatedCollectionData(ref, { limit: 2 }), {
+      initialProps: { ref: query(fruitsRef(), orderBy('name')) },
+    });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    await waitFor(() => {
+      expect(result.current.data.length).toBe(2);
+      expect(result.current.hasMore).toBe(true);
+    });
+
+    result.current.loadMore();
+    await waitFor(() => expect(result.current.loading).toBe(true));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    await waitFor(() => {
+      expect(result.current.data.length).toBe(4);
+    });
+
+    rerender({ ref: query(vegetablesRef(), orderBy('name')) });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    await waitFor(() => {
+      expect(result.current.data.length).toBe(2);
+      expect(result.current.hasMore).toBe(true);
     });
   });
 

--- a/src/firestore/_tests/usePaginatedCollectionDataOnce.test.ts
+++ b/src/firestore/_tests/usePaginatedCollectionDataOnce.test.ts
@@ -19,7 +19,9 @@ describe('usePaginatedCollectionDataOnce', async () => {
       addDoc(fruitsRef(), { name: 'cherry' }),
       addDoc(fruitsRef(), { name: 'date' }),
       addDoc(vegetablesRef(), { name: 'carrot' }),
+      addDoc(vegetablesRef(), { name: 'onion' }),
       addDoc(vegetablesRef(), { name: 'potato' }),
+      addDoc(vegetablesRef(), { name: 'tomato' }),
     ]);
   });
 
@@ -69,7 +71,53 @@ describe('usePaginatedCollectionDataOnce', async () => {
     await waitFor(() => {
       expect(result.current.data.length).toBe(2);
       expect(result.current.data).toContainEqual(expect.objectContaining({ name: 'carrot' }));
-      expect(result.current.data).toContainEqual(expect.objectContaining({ name: 'potato' }));
+      expect(result.current.data).toContainEqual(expect.objectContaining({ name: 'onion' }));
+    });
+  });
+
+  it('clears data when the query changes to null', async () => {
+    const { result, waitFor, rerender } = renderHook<
+      { ref: Parameters<typeof usePaginatedCollectionDataOnce>[0] },
+      ReturnType<typeof usePaginatedCollectionDataOnce>
+    >(({ ref }) => usePaginatedCollectionDataOnce(ref, { limit: 2 }), {
+      initialProps: { ref: query(fruitsRef(), orderBy('name')) },
+    });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    await waitFor(() => {
+      expect(result.current.data.length).toBe(2);
+      expect(result.current.data).toContainEqual(expect.objectContaining({ name: 'apple' }));
+      expect(result.current.data).toContainEqual(expect.objectContaining({ name: 'banana' }));
+    });
+
+    rerender({ ref: null });
+    await waitFor(() => {
+      expect(result.current.loading).toBe(undefined);
+      expect(result.current.data.length).toBe(0);
+    });
+  });
+
+  it('resets pagination when the query changes', async () => {
+    const { result, waitFor, rerender } = renderHook(({ ref }) => usePaginatedCollectionDataOnce(ref, { limit: 2 }), {
+      initialProps: { ref: query(fruitsRef(), orderBy('name')) },
+    });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    await waitFor(() => {
+      expect(result.current.data.length).toBe(2);
+      expect(result.current.hasMore).toBe(true);
+    });
+
+    result.current.loadMore();
+    await waitFor(() => expect(result.current.loading).toBe(true));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    await waitFor(() => {
+      expect(result.current.data.length).toBe(4);
+    });
+
+    rerender({ ref: query(vegetablesRef(), orderBy('name')) });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    await waitFor(() => {
+      expect(result.current.data.length).toBe(2);
+      expect(result.current.hasMore).toBe(true);
     });
   });
 

--- a/src/firestore/useCollectionData.ts
+++ b/src/firestore/useCollectionData.ts
@@ -20,7 +20,10 @@ export const useCollectionData = <T>(
   useQueriesEffect(() => {
     let isMounted = true;
     if (!query) {
-      isMounted && setData([]);
+      if (isMounted) {
+        setData([]);
+        setLoading(undefined);
+      }
       return;
     }
 

--- a/src/firestore/useCollectionDataOnce.ts
+++ b/src/firestore/useCollectionDataOnce.ts
@@ -20,7 +20,10 @@ export const useCollectionDataOnce = <T>(
   useQueriesEffect(() => {
     let isMounted = true;
     if (!query) {
-      isMounted && setData([]);
+      if (isMounted) {
+        setData([]);
+        setLoading(undefined);
+      }
       return;
     }
 

--- a/src/firestore/useDocumentData.ts
+++ b/src/firestore/useDocumentData.ts
@@ -20,7 +20,10 @@ export const useDocumentData = <T>(
   useRefsEffect(() => {
     let isMounted = true;
     if (!ref) {
-      isMounted && setData(undefined);
+      if (isMounted) {
+        setData(undefined);
+        setLoading(undefined);
+      }
       return;
     }
 

--- a/src/firestore/useDocumentDataOnce.ts
+++ b/src/firestore/useDocumentDataOnce.ts
@@ -20,7 +20,10 @@ export const useDocumentDataOnce = <T>(
   useRefsEffect(() => {
     let isMounted = true;
     if (!ref) {
-      isMounted && setData(undefined);
+      if (isMounted) {
+        setData(undefined);
+        setLoading(undefined);
+      }
       return;
     }
 

--- a/src/firestore/useDocumentsData.ts
+++ b/src/firestore/useDocumentsData.ts
@@ -20,7 +20,10 @@ export const useDocumentsData = <T>(
   useRefsEffect(() => {
     let isMounted = true;
     if (!refs || refs.length === 0) {
-      isMounted && setData([]);
+      if (isMounted) {
+        setData([]);
+        setLoading(undefined);
+      }
       return;
     }
 

--- a/src/firestore/useDocumentsDataOnce.ts
+++ b/src/firestore/useDocumentsDataOnce.ts
@@ -20,7 +20,10 @@ export const useDocumentsDataOnce = <T>(
   useRefsEffect(() => {
     let isMounted = true;
     if (!refs || refs.length === 0) {
-      isMounted && setData([]);
+      if (isMounted) {
+        setData([]);
+        setLoading(undefined);
+      }
       return;
     }
 

--- a/src/firestore/usePaginatedCollectionData.ts
+++ b/src/firestore/usePaginatedCollectionData.ts
@@ -2,6 +2,7 @@ import { limit, query } from 'firebase/firestore';
 import { useCallback, useMemo, useState } from 'react';
 import { useDeepCompareEffect } from '../utils/index.js';
 import { useCollectionData } from './useCollectionData.js';
+import { useQueriesEffect } from './useQueriesEffect.js';
 import type { Query, SnapshotOptions } from 'firebase/firestore';
 
 export type UsePaginatedCollectionDataOptions = {
@@ -33,6 +34,12 @@ export const usePaginatedCollectionData = <T>(
     if (loading) return;
     setData(_data);
   }, [loading, _data]);
+
+  // NOTE: Reset pagination when query changes.
+  useQueriesEffect(() => {
+    setData([]);
+    setPage(defaultPage);
+  }, [_query]);
 
   return { data: dataWithoutLast, loading, hasMore, loadMore, error };
 };

--- a/src/firestore/usePaginatedCollectionDataOnce.ts
+++ b/src/firestore/usePaginatedCollectionDataOnce.ts
@@ -2,6 +2,7 @@ import { limit, query } from 'firebase/firestore';
 import { useCallback, useMemo, useState } from 'react';
 import { useDeepCompareEffect } from '../utils/index.js';
 import { useCollectionDataOnce } from './useCollectionDataOnce.js';
+import { useQueriesEffect } from './useQueriesEffect.js';
 import type { Query, SnapshotOptions } from 'firebase/firestore';
 
 export type UsePaginatedCollectionDataOnceOptions = {
@@ -33,6 +34,12 @@ export const usePaginatedCollectionDataOnce = <T>(
     if (loading) return;
     setData(_data);
   }, [loading, _data]);
+
+  // NOTE: Reset pagination when query changes.
+  useQueriesEffect(() => {
+    setData([]);
+    setPage(defaultPage);
+  }, [_query]);
 
   return { data: dataWithoutLast, loading, hasMore, loadMore, error };
 };


### PR DESCRIPTION
- usePaginated
  - queryが変更されたらdata/pageが初期化されるように
  - ↓の修正でloadingも初期化されるようになる
- usePaginated以外
  - ref/queryがnull/undefinedになったらloadingも初期化するように

errorのクリアも追加したほうがいいけど複雑になりそうだったので別PRに分けた（こっちだけ早くリリースしたいので）